### PR TITLE
Fix Tertiary header typo

### DIFF
--- a/Runtime/UI/UIComponents/scripts/SO/ThemeSO.cs
+++ b/Runtime/UI/UIComponents/scripts/SO/ThemeSO.cs
@@ -15,7 +15,7 @@ public class ThemeSO : ScriptableObject
     public Color Secondary_text;
     public TMP_FontAsset Secondary_font;
     
-    [Header("Tirtiary")] 
+    [Header("Tertiary")]
     public Color Tirtiary_bg;
     public Color Tirtiary_text;
     public TMP_FontAsset Tirtiary_font;


### PR DESCRIPTION
## Summary
- correct spelling of `[Header("Tertiary")]` in `ThemeSO.cs`
- verified there are no documentation or comment references to the old spelling

## Testing
- `grep -n "Tirtiary" -R --include=*.cs --include=*.md`


------
https://chatgpt.com/codex/tasks/task_e_686399076de08324a3b24bff1db68427